### PR TITLE
Refactor bridge_info.json to support HA

### DIFF
--- a/common/bridge_info.json
+++ b/common/bridge_info.json
@@ -1,12 +1,20 @@
 {
     "child" : {
-        "url": "http://127.0.0.1:8551",
+        "urls": [
+            "http://127.0.0.1:8551"
+        ],
         "key": "0xc544b44c1c58955af516c1f2ff17f8fd522604f1ea6b64db79e067343ed5e307",
-        "operator": "0x37ca5a315d5e17e428bb5edff2b6f2e6211bbe39"
+        "operators": [
+            "0x37ca5a315d5e17e428bb5edff2b6f2e6211bbe39"
+        ]
     },
     "parent" : {
-        "url": "http://127.0.0.1:9781",
+        "urls": [
+            "http://127.0.0.1:9781"
+        ],
         "key": "0x4b07ca7412ad2bb0e62db30369b9f08a8724fb81fce4b3b1af23800233074fbf",
-        "operator": "0xd5c0321bafc1d82ccd5cb60c0d943328c9d93318"
+        "operators": [
+            "0xd5c0321bafc1d82ccd5cb60c0d943328c9d93318"
+        ]
     }
 }

--- a/erc20/alias-erc20-deploy.js
+++ b/erc20/alias-erc20-deploy.js
@@ -29,7 +29,7 @@ async function jsonRpcReq(url, log, method, params) {
   });
 }
 async function deploy(info) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -59,19 +59,27 @@ async function deploy(info) {
 
   // add minter
   await conf.child.newInstance.methods.addMinter(conf.child.bridge).send({ from: conf.child.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
-  await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
+  await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.parent.bridge, gas: 100000000, value: 0 });
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
 
   // register token
   await conf.child.newInstanceBridge.methods.registerToken(conf.child.token, conf.parent.token).send({ from: conf.child.sender, gas: 100000000, value: 0 });
   await conf.parent.newInstanceBridge.methods.registerToken(conf.parent.token, conf.child.token).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -79,23 +87,18 @@ async function deploy(info) {
           console.log("Error:", err);
       }
   })
-  
+
   const alias = "MYBRIDGE2"
-  const url = conf.child.url;
-  log = 'registering bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_registerBridgeByAlias', [alias, conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_registerBridgeByAlias', [alias, conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridgeByAlias', [alias]);
+    log = 'subscribing bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridgeByAlias', [alias]);
 
-  log = 'register token to subbridge..'
-  await jsonRpcReq(url, log, 'subbridge_registerTokenByAlias', [alias, conf.child.token, conf.parent.token]);
+    log = 'register token to subbridge..'
+    await jsonRpcReq(url, log, 'subbridge_registerTokenByAlias', [alias, conf.child.token, conf.parent.token]);
+  }
 
-  /*
-   * Initialize service chain configuration with three logs via interaction with attached console
-  console.log(`subbridge.registerBridgeByAlias("${alias}", "${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridgeByAlias("${alias}")`)
-  console.log(`subbridge.registerTokenByAlias("${alias}", "${conf.child.token}", "${conf.parent.token}")`)
-  */
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/erc20/erc20-deploy.js
+++ b/erc20/erc20-deploy.js
@@ -30,7 +30,7 @@ async function jsonRpcReq(url, log, method, params) {
 }
 
 async function deploy(info) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -60,19 +60,27 @@ async function deploy(info) {
 
   // add minter
   await conf.child.newInstance.methods.addMinter(conf.child.bridge).send({ from: conf.child.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
-  await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
+  await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.parent.bridge, gas: 100000000, value: 0 });
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
 
   // register token
   await conf.child.newInstanceBridge.methods.registerToken(conf.child.token, conf.parent.token).send({ from: conf.child.sender, gas: 100000000, value: 0 });
   await conf.parent.newInstanceBridge.methods.registerToken(conf.parent.token, conf.child.token).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -80,22 +88,17 @@ async function deploy(info) {
           console.log("Error:", err);
       }
   })
-  
-  const url = conf.child.url;
-  log = 'registering bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'register token to subbridge..'
-  await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+    log = 'subscribing bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  /*
-   * Initialize service chain configuration with three logs via interaction with attached console
-  console.log(`subbridge.registerBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.registerToken("${conf.child.bridge}", "${conf.parent.bridge}", "${conf.child.token}", "${conf.parent.token}")`)
-  */
+    log = 'register token to subbridge..'
+    await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+  }
+
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/erc20/erc20-transfer-1step.js
+++ b/erc20/erc20-transfer-1step.js
@@ -12,18 +12,18 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(tokenAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(tokenAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 
   conf.child.sender = scnCaver.klay.accounts.wallet.add(conf.child.key).address;
   conf.parent.sender = enCaver.klay.accounts.wallet.add(conf.parent.key).address;
   const alice = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
-  
+
   try {
     let balance = await scnInstance.methods.balanceOf(alice).call();
     console.log("alice balance:", balance);

--- a/erc20/erc20-transfer-2step.js
+++ b/erc20/erc20-transfer-2step.js
@@ -12,11 +12,11 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(tokenAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(tokenAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/erc721/erc721-transfer-1step.js
+++ b/erc721/erc721-transfer-1step.js
@@ -27,18 +27,18 @@ async function getFreshToken() {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(nftAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(nftAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 
   conf.child.sender = scnCaver.klay.accounts.wallet.add(conf.child.key).address;
   conf.parent.sender = enCaver.klay.accounts.wallet.add(conf.parent.key).address;
   const alice = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
-  
+
   try {
     const tokenURI = "https://www.klaytn.com";
     const tokenId = await getFreshToken();
@@ -47,7 +47,7 @@ async function getFreshToken() {
     await enInstance.methods.mintWithTokenURI(conf.parent.sender, tokenId, tokenURI).send({from: conf.parent.sender, gas:1000000});
     let owner = await enInstance.methods.ownerOf(tokenId).call();
     console.log(`Current owner: ${owner}`);
-    
+
     console.log(`Transfer the tokenId (${tokenId}) to ${alice}`);
     // Transfer main chain to service chain
     await enInstance.methods.requestValueTransfer(tokenId, alice, []).send({from: conf.parent.sender, gas:1000000});

--- a/erc721/erc721-transfer-2step.js
+++ b/erc721/erc721-transfer-2step.js
@@ -27,11 +27,11 @@ async function getFreshToken() {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(nftAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(nftAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -20,18 +20,18 @@ Note that it deploys both bridge contracts and ServiceChain tokens on the same n
 
 ```
 mainbridge: {
-  url: "http://127.0.0.1:8554",
+  urls: ["http://127.0.0.1:8554"],
   chainId: 1000,
   gasPrice: 25000000000,
       ...
-  operator: '0x9388349e71140c1f099ca8293892ab0d1e151d4f',
+  operators: ['0x9388349e71140c1f099ca8293892ab0d1e151d4f'],
 },
 subbridge: {
-  url: "http://127.0.0.1:8555",
+  urls: ["http://127.0.0.1:8555"],
   chainId: 1001,
   gasPrice: 25000000000,
       ...
-  operator: '0xcb5e2874276d3a96ab6331cafeb80baa6453eeb0',
+  operators: ['0xcb5e2874276d3a96ab6331cafeb80baa6453eeb0'],
 },
 ```
 

--- a/hardhat/hardhat.config.js
+++ b/hardhat/hardhat.config.js
@@ -49,7 +49,7 @@ task("deploy", "Deploy bridge and token contracts to both EN and SCN", async (ta
 
   await token.addMinter(bridge.address);
 
-  await bridge.registerOperator(hre.network.config.operator);
+  await bridge.registerOperator(hre.network.config.operators[0]);
 
   if (hre.network.name == 'mainbridge') {
     conf.mainbridge.bridge = bridge.address;
@@ -74,7 +74,7 @@ task("regtoken", "Register operator and token to bridge", async (taskArgs, hre) 
   else {
     await bridge.registerToken(c.token, conf.mainbridge.token);
   }
-  await bridge.transferOwnership(hre.network.config.operator);
+  await bridge.transferOwnership(hre.network.config.operators[0]);
 
   if (hre.network.name == 'subbridge') {
     await hre.network.provider.request({
@@ -127,7 +127,7 @@ module.exports = {
   },
   networks: {
     mainbridge: {
-      url: "http://127.0.0.1:8554",
+      urls: ["http://127.0.0.1:8554"],
       chainId: 1000,
       gas: 50000000,
       gasPrice: 25000000000,
@@ -135,10 +135,10 @@ module.exports = {
         mnemonic: "test test test test test test test test test test test junk",
         initialIndex: 0,
       },
-      operator: '0x9388349e71140c1f099ca8293892ab0d1e151d4f',
+      operators: ['0x9388349e71140c1f099ca8293892ab0d1e151d4f'],
     },
     subbridge: {
-      url: "http://127.0.0.1:8555",
+      urls: ["http://127.0.0.1:8555"],
       chainId: 1001,
       gas: 50000000,
       gasPrice: 25000000000,
@@ -146,7 +146,7 @@ module.exports = {
         mnemonic: "test test test test test test test test test test test junk",
         initialIndex: 1,
       },
-      operator: '0xcb5e2874276d3a96ab6331cafeb80baa6453eeb0',
+      operators: ['0xcb5e2874276d3a96ab6331cafeb80baa6453eeb0'],
     },
     hardhat: {
       accounts: {

--- a/kip17/kip17-deploy.js
+++ b/kip17/kip17-deploy.js
@@ -30,7 +30,7 @@ async function jsonRpcReq(url, log, method, params) {
 }
 
 async function deploy(info) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -63,16 +63,24 @@ async function deploy(info) {
   await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
 
   // register token
   await conf.child.newInstanceBridge.methods.registerToken(conf.child.token, conf.parent.token).send({ from: conf.child.sender, gas: 100000000, value: 0 });
   await conf.parent.newInstanceBridge.methods.registerToken(conf.parent.token, conf.child.token).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -81,21 +89,16 @@ async function deploy(info) {
       }
   });
 
-  const url = conf.child.url;
-  log = 'registering bridges to the child node';
-  await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node';
+    await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node';
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+    log = 'subscribing bridges to the child node';
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'register token to subbridge..';
-  await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+    log = 'register token to subbridge..';
+    await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+  }
 
-  /*
-   * Initialize service chain configuration with three logs via interaction with attached console
-  console.log(`subbridge.registerBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.registerToken("${conf.child.bridge}", "${conf.parent.bridge}", "${conf.child.token}", "${conf.parent.token}")`)
-  */
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/kip17/kip17-transfer-2step-erc721-interface.js
+++ b/kip17/kip17-transfer-2step-erc721-interface.js
@@ -27,11 +27,11 @@ async function getFreshToken() {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(nftAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(nftAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/kip7/kip7-deploy.js
+++ b/kip7/kip7-deploy.js
@@ -30,7 +30,7 @@ async function jsonRpcReq(url, log, method, params) {
 }
 
 async function deploy(info) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -63,16 +63,24 @@ async function deploy(info) {
   await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
 
   // register token
   await conf.child.newInstanceBridge.methods.registerToken(conf.child.token, conf.parent.token).send({ from: conf.child.sender, gas: 100000000, value: 0 });
   await conf.parent.newInstanceBridge.methods.registerToken(conf.parent.token, conf.child.token).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -80,22 +88,17 @@ async function deploy(info) {
           console.log("Error:", err);
       }
   })
-  
-  const url = conf.child.url;
-  log = 'registering bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'register token to subbridge..'
-  await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+    log = 'subscribing bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  /*
-   * Initialize service chain configuration with three logs via interaction with attached console
-  console.log(`subbridge.registerBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.registerToken("${conf.child.bridge}", "${conf.parent.bridge}", "${conf.child.token}", "${conf.parent.token}")`)
-  */
+    log = 'register token to subbridge..'
+    await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+  }
+
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/kip7/kip7-transfer-2step-erc20-interface.js
+++ b/kip7/kip7-transfer-2step-erc20-interface.js
@@ -12,11 +12,11 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(tokenAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(tokenAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/klay/klay-deploy.js
+++ b/klay/klay-deploy.js
@@ -29,7 +29,7 @@ async function jsonRpcReq(url, log, method, params) {
 }
 
 async function deploy(info, bridgeIdentity) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -65,12 +65,20 @@ async function deploy(info, bridgeIdentity) {
   await deploy(conf.parent, 'parent');
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
+
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -78,17 +86,14 @@ async function deploy(info, bridgeIdentity) {
           console.log("Error:", err);
       }
   })
-  
-  const url = conf.child.url;
-  log = 'registering bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-/*
-  console.log(`subbridge.registerBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-*/
+    log = 'subscribing bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+  }
+
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/klay/klay-transfer.js
+++ b/klay/klay-transfer.js
@@ -12,11 +12,11 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
   conf.child.sender = scnCaver.klay.accounts.wallet.add(conf.child.key).address;
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
   conf.parent.sender = enCaver.klay.accounts.wallet.add(conf.parent.key).address;
 
@@ -29,7 +29,7 @@ function sleep(ms) {
 
     const senderBalance = await enCaver.utils.convertFromPeb(await enCaver.rpc.klay.getBalance(conf.parent.sender));
     assert(senderBalance >= initialAmount);
-    
+
     // Send KLAY from the sender on parent chain to bridge contract on the parent chain
     await enInstanceBridge.methods.chargeWithoutEvent().send({from: conf.parent.sender, gas: 100000000, value: initialAmount});
 

--- a/native-kip17/kip17-deploy.js
+++ b/native-kip17/kip17-deploy.js
@@ -23,7 +23,7 @@ async function jsonRpcReq(url, log, method, params) {
 }
 
 async function deploy(info) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -56,16 +56,24 @@ async function deploy(info) {
   await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
 
   // register token
   await conf.child.newInstanceBridge.methods.registerToken(conf.child.token, conf.parent.token).send({ from: conf.child.sender, gas: 100000000, value: 0 });
   await conf.parent.newInstanceBridge.methods.registerToken(conf.parent.token, conf.child.token).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -74,21 +82,16 @@ async function deploy(info) {
       }
   });
 
-  const url = conf.child.url;
-  log = 'registering bridges to the child node';
-  await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node';
+    await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node';
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+    log = 'subscribing bridges to the child node';
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'register token to subbridge..';
-  await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+    log = 'register token to subbridge..';
+    await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+  }
 
-  /*
-   * Initialize service chain configuration with three logs via interaction with attached console
-  console.log(`subbridge.registerBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.registerToken("${conf.child.bridge}", "${conf.parent.bridge}", "${conf.child.token}", "${conf.parent.token}")`)
-  */
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/native-kip17/kip17-transfer-1step.js
+++ b/native-kip17/kip17-transfer-1step.js
@@ -27,18 +27,18 @@ async function getFreshToken() {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(nftAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(nftAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 
   conf.child.sender = scnCaver.klay.accounts.wallet.add(conf.child.key).address;
   conf.parent.sender = enCaver.klay.accounts.wallet.add(conf.parent.key).address;
   const alice = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
-  
+
   try {
     const tokenURI = "https://www.klaytn.com";
     const tokenId = await getFreshToken();

--- a/native-kip17/kip17-transfer-2step-erc721-interface.js
+++ b/native-kip17/kip17-transfer-2step-erc721-interface.js
@@ -27,11 +27,11 @@ async function getFreshToken() {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(nftAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(nftAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/native-kip17/kip17-transfer-2step.js
+++ b/native-kip17/kip17-transfer-2step.js
@@ -27,11 +27,11 @@ async function getFreshToken() {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(nftAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(nftAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/native-kip7/kip7-deploy.js
+++ b/native-kip7/kip7-deploy.js
@@ -30,7 +30,7 @@ async function jsonRpcReq(url, log, method, params) {
 }
 
 async function deploy(info) {
-  const caver = new Caver(info.url);
+  const caver = new Caver(info.urls[0]);
   info.sender = caver.klay.accounts.wallet.add(info.key).address;
 
   try {
@@ -63,16 +63,24 @@ async function deploy(info) {
   await conf.parent.newInstance.methods.addMinter(conf.parent.bridge).send({ from: conf.parent.sender, to: conf.child.bridge, gas: 100000000, value: 0 });
 
   // register operator
-  await conf.child.newInstanceBridge.methods.registerOperator(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.registerOperator(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  for (const operator of conf.child.operators) {
+    await conf.child.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  }
+  for (const operator of conf.parent.operators) {
+    await conf.parent.newInstanceBridge.methods.registerOperator(operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  }
 
   // register token
   await conf.child.newInstanceBridge.methods.registerToken(conf.child.token, conf.parent.token).send({ from: conf.child.sender, gas: 100000000, value: 0 });
   await conf.parent.newInstanceBridge.methods.registerToken(conf.parent.token, conf.child.token).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
+  // setOperatorThreshold
+  await conf.child.newInstanceBridge.methods.setOperatorThreshold(0, conf.child.operators.length).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.setOperatorThreshold(0, conf.parent.operators.length).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+
   // transferOwnership
-  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operator).send({ from: conf.child.sender, gas: 100000000, value: 0 });
-  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operator).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
+  await conf.child.newInstanceBridge.methods.transferOwnership(conf.child.operators[0]).send({ from: conf.child.sender, gas: 100000000, value: 0 });
+  await conf.parent.newInstanceBridge.methods.transferOwnership(conf.parent.operators[0]).send({ from: conf.parent.sender, gas: 100000000, value: 0 });
 
   const filename  = "transfer_conf.json"
   fs.writeFile(filename, JSON.stringify(conf), (err) => {
@@ -80,22 +88,17 @@ async function deploy(info) {
           console.log("Error:", err);
       }
   })
-  
-  const url = conf.child.url;
-  log = 'registering bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'subscribing bridges to the child node'
-  await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
+  for (const url of conf.child.urls) {
+    log = 'registering bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_registerBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  log = 'register token to subbridge..'
-  await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+    log = 'subscribing bridges to the child node'
+    await jsonRpcReq(url, log, 'subbridge_subscribeBridge', [conf.child.bridge, conf.parent.bridge]);
 
-  /*
-   * Initialize service chain configuration with three logs via interaction with attached console
-  console.log(`subbridge.registerBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.subscribeBridge("${conf.child.bridge}", "${conf.parent.bridge}")`)
-  console.log(`subbridge.registerToken("${conf.child.bridge}", "${conf.parent.bridge}", "${conf.child.token}", "${conf.parent.token}")`)
-  */
+    log = 'register token to subbridge..'
+    await jsonRpcReq(url, log, 'subbridge_registerToken', [conf.child.bridge, conf.parent.bridge, conf.child.token, conf.parent.token]);
+  }
+
   console.log(`------------------------- ${testcase} END -------------------------`)
 })();

--- a/native-kip7/kip7-transfer-1step.js
+++ b/native-kip7/kip7-transfer-1step.js
@@ -12,18 +12,18 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(tokenAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(tokenAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 
   conf.child.sender = scnCaver.klay.accounts.wallet.add(conf.child.key).address;
   conf.parent.sender = enCaver.klay.accounts.wallet.add(conf.parent.key).address;
   const alice = "0xc40b6909eb7085590e1c26cb3becc25368e249e9";
-  
+
   try {
     let balance = await scnInstance.methods.balanceOf(alice).call();
     console.log("alice balance:", balance);

--- a/native-kip7/kip7-transfer-2step-erc20-interface.js
+++ b/native-kip7/kip7-transfer-2step-erc20-interface.js
@@ -12,11 +12,11 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(tokenAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(tokenAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 

--- a/native-kip7/kip7-transfer-2step.js
+++ b/native-kip7/kip7-transfer-2step.js
@@ -12,11 +12,11 @@ function sleep(ms) {
 (async function TokenTransfer() {
   const testcase = process.argv[1].substring(process.argv[1].lastIndexOf('/') + 1).replace(/\.[^/.]+$/, "");
   console.log(`------------------------- ${testcase} START -------------------------`)
-  const scnCaver = new Caver(conf.child.url);
+  const scnCaver = new Caver(conf.child.urls[0]);
   const scnInstance = new scnCaver.klay.Contract(tokenAbi, conf.child.token);
   const scnInstanceBridge = new scnCaver.klay.Contract(bridgeAbi, conf.child.bridge);
 
-  const enCaver = new Caver(conf.parent.url);
+  const enCaver = new Caver(conf.parent.urls[0]);
   const enInstance = new enCaver.klay.Contract(tokenAbi, conf.parent.token);
   const enInstanceBridge = new enCaver.klay.Contract(bridgeAbi, conf.parent.bridge);
 


### PR DESCRIPTION
This value transfer example repository requires at least one pre-configured bridge. The user can provide the information for configured bridge via the `bridge_info.json` file. However, it assumes a sole-bridge configuration, and the user should manually register additional bridges using Caver and subbridge RPC.

To provide an example that support HA configured bridge, this PR refactors the `bridge_info.json` to accept list of bridges. When the value transfer script deploys a bridge contract, it can register additional bridges by looping the list of bridges.

The original structure of `bridge_info.json` is as follows:
```
{
    "child" : {
        "url": "http://127.0.0.1:8551",
        "key": "0xc544b44c1c58955af516c1f2ff17f8fd522604f1ea6b64db79e067343ed5e307",
        "operator": "0x7920de6f6d9d1e9fe2e35b48ab8cfce545673888"
    },
    "parent" : {
        "url": "http://127.0.0.1:9781",
        "key": "0x4b07ca7412ad2bb0e62db30369b9f08a8724fb81fce4b3b1af23800233074fbf",
        "operator": "0xa36a4d6d15fa692eceaa616008bc2decc5c0403b"
    }
}
```
This PR suggests to change `bridge_info.json` to:
```
{
    "child" : {
        "urls": ["http://127.0.0.1:8551"],
        "key": "0xc544b44c1c58955af516c1f2ff17f8fd522604f1ea6b64db79e067343ed5e307",
        "operators": ["0x7920de6f6d9d1e9fe2e35b48ab8cfce545673888"]
    },
    "parent" : {
        "urls": ["http://127.0.0.1:9781"],
        "key": "0x4b07ca7412ad2bb0e62db30369b9f08a8724fb81fce4b3b1af23800233074fbf",
        "operators": ["0xa36a4d6d15fa692eceaa616008bc2decc5c0403b"]
    }
}
```

The new structure works well even if there is only one bridge; the user can provide only one item in the list.